### PR TITLE
Prompt navigation

### DIFF
--- a/src/napari_sam2/_widget.py
+++ b/src/napari_sam2/_widget.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import (
     QPushButton,
     QWidget,
     QVBoxLayout,
+    QScrollArea
 )
 
 from napari_sam2.data_widget import DataWidget
@@ -26,9 +27,23 @@ class SAM2MainWidget(QWidget):
         super().__init__()
         self.viewer = viewer
 
-        self.setLayout(QVBoxLayout())
         # self.layout().setAlignment(qtpy.QtCore.Qt.AlignTop)
 
+        # Wrap current layout in a container
+        self.container = QWidget()
+        self.container_layout = QVBoxLayout(self.container)
+        self.container.setLayout(self.container_layout)
+
+        # Scroll area
+        self.scroll = QScrollArea()
+        self.scroll.setWidgetResizable(True)
+        self.scroll.setWidget(self.container)
+
+        # Main layout just contains the scroll area
+        main_layout = QVBoxLayout(self)
+        main_layout.addWidget(self.scroll)
+        self.setLayout(main_layout)
+        
         # Create a horizontal layout for the buttons
         button_layout = QHBoxLayout()
         button_layout.setContentsMargins(0, 0, 0, 0)

--- a/src/napari_sam2/data_widget.py
+++ b/src/napari_sam2/data_widget.py
@@ -98,6 +98,8 @@ class DataWidget(SAM2Subwidget):
             self.image_layer_dropdown.removeItem(
                 self.image_layer_dropdown.findText(event.value.name)
             )
+        if "prompt" in self.parent.subwidgets:
+            self.parent.subwidgets["prompt"].refresh_prompt_scroll_widget()
 
     def switch_selected_layer(self, event):
         # Integer means we're switching layers via the dropdown, not selection

--- a/src/napari_sam2/subwidget.py
+++ b/src/napari_sam2/subwidget.py
@@ -44,4 +44,5 @@ class SAM2Subwidget(QGroupBox):
         # Add the layout to the group box
         self.setLayout(self.layout)
         # Add the group box to the main layout
-        self.parent.layout().addWidget(self)
+        # self.parent.layout().addWidget(self)
+        self.parent.container_layout.addWidget(self)


### PR DESCRIPTION
closes #13 

Added: Prompt navigation region with 
- Checkbox for restricting navigation to current label
- Forward/back arrows
- Clickable slice sliced with coloured tickmarks indicating prompted frames


_still to do: remove prompt ticks from the slider on clear/reset layers_